### PR TITLE
Added support for Rails 4

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,8 +1,2 @@
 source 'https://rubygems.org'
 gemspec
-
-gem 'activerecord', '~>3.0'
-gem 'activerecord-postgres-hstore', '~>0.4'
-gem 'pg', '~>0.14'
-gem 'rspec', '~>2'
-gem 'rake'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,52 +2,50 @@ PATH
   remote: .
   specs:
     hstore_flags (0.2.0)
-      activerecord (~> 3.1)
-      activerecord-postgres-hstore (~> 0.7.5)
+      activerecord (~> 4.0)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    activemodel (3.2.13)
-      activesupport (= 3.2.13)
-      builder (~> 3.0.0)
-    activerecord (3.2.13)
-      activemodel (= 3.2.13)
-      activesupport (= 3.2.13)
-      arel (~> 3.0.2)
-      tzinfo (~> 0.3.29)
-    activerecord-postgres-hstore (0.7.6)
-      activerecord (>= 3.1)
-      pg-hstore (>= 1.1.5)
-      rake
-    activesupport (3.2.13)
-      i18n (= 0.6.1)
-      multi_json (~> 1.0)
-    arel (3.0.2)
-    builder (3.0.4)
+    activemodel (4.0.0)
+      activesupport (= 4.0.0)
+      builder (~> 3.1.0)
+    activerecord (4.0.0)
+      activemodel (= 4.0.0)
+      activerecord-deprecated_finders (~> 1.0.2)
+      activesupport (= 4.0.0)
+      arel (~> 4.0.0)
+    activerecord-deprecated_finders (1.0.3)
+    activesupport (4.0.0)
+      i18n (~> 0.6, >= 0.6.4)
+      minitest (~> 4.2)
+      multi_json (~> 1.3)
+      thread_safe (~> 0.1)
+      tzinfo (~> 0.3.37)
+    arel (4.0.0)
+    atomic (1.1.14)
+    builder (3.1.4)
     diff-lcs (1.2.4)
-    i18n (0.6.1)
-    multi_json (1.7.3)
-    pg (0.15.1)
-    pg-hstore (1.1.7)
-    rake (10.0.4)
-    rspec (2.13.0)
-      rspec-core (~> 2.13.0)
-      rspec-expectations (~> 2.13.0)
-      rspec-mocks (~> 2.13.0)
-    rspec-core (2.13.1)
-    rspec-expectations (2.13.0)
+    i18n (0.6.5)
+    minitest (4.7.5)
+    multi_json (1.8.0)
+    pg (0.17.0)
+    rspec (2.14.1)
+      rspec-core (~> 2.14.0)
+      rspec-expectations (~> 2.14.0)
+      rspec-mocks (~> 2.14.0)
+    rspec-core (2.14.5)
+    rspec-expectations (2.14.3)
       diff-lcs (>= 1.1.3, < 2.0)
-    rspec-mocks (2.13.1)
+    rspec-mocks (2.14.3)
+    thread_safe (0.1.3)
+      atomic
     tzinfo (0.3.37)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  activerecord (~> 3.0)
-  activerecord-postgres-hstore (~> 0.4)
   hstore_flags!
-  pg (~> 0.14)
-  rake
-  rspec (~> 2)
+  pg
+  rspec

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ integer/bit flags aggrevating you? try this.
 Requirements
 ------------
 
-* Rails 3.0 or greater
+* Rails 4.0 or greater
 * Postgresql 8.4+ with contrib package
 * Read [activerecord-postgres-hstore](https://raw.github.com/engageis/activerecord-postgres-hstore) for index creation
 

--- a/hstore_flags.gemspec
+++ b/hstore_flags.gemspec
@@ -12,8 +12,7 @@ Gem::Specification.new do |s|
   s.license       = "MIT"
   s.require_paths = ["lib"]
 
-  s.add_dependency "activerecord", "~> 3.1"
-  s.add_dependency "activerecord-postgres-hstore", "~> 0.7.5"
+  s.add_dependency "activerecord", "~> 4.0"
 
   s.add_development_dependency "rspec"
   s.add_development_dependency "pg"

--- a/lib/hstore_flags/version.rb
+++ b/lib/hstore_flags/version.rb
@@ -1,3 +1,3 @@
 module HStoreFlags
-  Version = VERSION = "0.2.0"
+  Version = VERSION = "0.3.0"
 end


### PR DESCRIPTION
Changes:
- use built-in Rails database adapter instead of old serialize call
- update to use new `scope` syntax that requires a lambda
- simplify code by using ActiveSupport::Concern
- DRY up declaration of "true" value
- fix a bug that requires `("#{field}_will_change!"` to be called
  before mutating the actual flags hash
- remove unnecessary bundler Gemfile entries
