### PR TITLE
class#::AVAILABLE_#{field} shows available flags

### DIFF
--- a/lib/hstore_flags.rb
+++ b/lib/hstore_flags.rb
@@ -33,6 +33,12 @@ module HStoreFlags
       field = opts[:field] || "flags"
       table_field = "#{self.table_name}." + field
 
+      #const_set('TEST', 'fubar')
+
+      class_exec do
+        const_set("AVAILABLE_#{field.upcase}", args)
+      end
+
       args.each do |flag|
         define_method("#{flag}")      {(self[field] || {})[flag.to_s] == STORED_TRUE_VALUE}
         define_method("#{flag}?")     {(self[field] || {})[flag.to_s] == STORED_TRUE_VALUE}

--- a/spec/hstore_flags_spec.rb
+++ b/spec/hstore_flags_spec.rb
@@ -16,6 +16,13 @@ class UserMultiFlags < ActiveRecord::Base
 end
 
 describe HStoreFlags do
+
+  it "shows available hstore flags" do
+    expect(User::AVAILABLE_FLAGS).to eq [:fighter, :lover]
+    expect(UserMultiFlags::AVAILABLE_MORE_FLAGS).to eq [:drinker, :smoker, :bartender]
+    expect { User::AVAILABLE_MORE_FLAGS }.to raise_error
+  end
+
   it "creates accessors for flags" do
     u = User.new(fighter: true)
     expect(u.fighter).to eq(true)


### PR DESCRIPTION
Dynamically inject a class constant which returns an array of
available (known) flags. I.e. when using the default name and
extending a model named User with the flags [:flag1, :flag2]

User::AVAILABLE_FLAGS will return [:flag1, :flag2]
